### PR TITLE
[DOC-928][fix]

### DIFF
--- a/backend/src/main/scala/com/griddynamics/genesis/service/impl/ProjectAuthorityService.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/service/impl/ProjectAuthorityService.scala
@@ -43,8 +43,8 @@ class ProjectAuthorityService(aclService: MutableAclService) extends service.Pro
   val projectAuthorities = authorityPermissionMap.keys
 
   @Transactional(readOnly = true)
-  def isUserProjectAdmin(username: String, groups: Iterable[UserGroup]):Boolean = {
-    val groupNames = groups.map ( "GROUP_" + _.name )
+  def isUserProjectAdmin(username: String, groups: Iterable[String]):Boolean = {
+    val groupNames = groups.map ( "GROUP_" + _)
     from(aclSid, aclEntry)((sid, entry) => where(
       ((sid.principal === true and sid.sid === username) or (sid.principal === false and (sid.sid in groupNames)))
         and (sid.id === entry.sid and entry.mask === BasePermission.ADMINISTRATION.getMask)

--- a/frontend/src/main/scala/com/griddynamics/genesis/spring/security/GenesisUserDetailsService.scala
+++ b/frontend/src/main/scala/com/griddynamics/genesis/spring/security/GenesisUserDetailsService.scala
@@ -56,7 +56,7 @@ class GenesisUserDetailsService( adminUsername: String,
           authorityService.getAuthorities(groups) ++
             authorityService.getUserAuthorities(user.username) ++
             groups.map("GROUP_" + _.name) ++
-            (if (projectAuthorityService.isUserProjectAdmin(user.username, groups)) List(GenesisRole.ProjectAdmin.toString) else List())
+            (if (projectAuthorityService.isUserProjectAdmin(user.username, groups.map(_.name))) List(GenesisRole.ProjectAdmin.toString) else List())
           ).distinct
         if(!authorities.contains(GenesisRole.GenesisUser.toString)) {
           throw new UsernameNotFoundException("User doesn't have required role [%s]".format(GenesisRole.GenesisUser))

--- a/internal-api/src/main/scala/com/griddynamics/genesis/service/ProjectAuthorityService.scala
+++ b/internal-api/src/main/scala/com/griddynamics/genesis/service/ProjectAuthorityService.scala
@@ -22,14 +22,14 @@
  */
 package com.griddynamics.genesis.service
 
-import com.griddynamics.genesis.api.{UserGroup, ExtendedResult, RequestResult}
+import com.griddynamics.genesis.api.{ExtendedResult, RequestResult}
 import com.griddynamics.genesis.users.GenesisRole
 
 trait ProjectAuthorityService {
   def projectAuthorities: Iterable[GenesisRole.Value]
   def updateProjectAuthority(projectId: Int, roleName: GenesisRole.Value, users: List[String], groups: List[String]): RequestResult
   def getProjectAuthority(projectId: Int, authorityName: GenesisRole.Value): ExtendedResult[(Iterable[String], Iterable[String])]
-  def isUserProjectAdmin(username: String, groups: Iterable[UserGroup]): Boolean
+  def isUserProjectAdmin(username: String, groups: Iterable[String]): Boolean
   def getGrantedAuthorities(projectId: Int, username: String, grantedAuthorities: Iterable[String]): List[GenesisRole.Value]
   def getAllowedProjectIds(username: String, authorities: Iterable[String]): List[Int]
   def removeUserFromProjects(username: String)

--- a/ui/src/main/resources/app/modules/settings/roles.js
+++ b/ui/src/main/resources/app/modules/settings/roles.js
@@ -167,7 +167,7 @@ function(genesis, status, backend, Users, Backbone, $) {
     },
 
 
-    initCompletion: function(){
+    initCompletion: function(hasGroups, hasUsers){
       var users = new Users.Collections.Users();
       var groups = new Users.Collections.Groups();
       var self = this;
@@ -179,7 +179,7 @@ function(genesis, status, backend, Users, Backbone, $) {
           filter_case: true,
           filter_hide: true,
           filter_selected: true,
-          newel: _.size(groups) == 0,
+          newel: !hasGroups,
           width: "100%",
           input_name: "groups-select",
           complete_text: "Enter group name...",
@@ -192,7 +192,7 @@ function(genesis, status, backend, Users, Backbone, $) {
           filter_case: true,
           filter_hide: true,
           filter_selected: true,
-          newel: _.size(users) == 0,
+          newel: !hasUsers,
           width: "100%",
           input_name: "users-select",
           complete_text: "Enter username...",
@@ -205,7 +205,7 @@ function(genesis, status, backend, Users, Backbone, $) {
       var self = this;
       $.when(backend.UserManager.hasUsers(), backend.UserManager.hasGroups(), genesis.fetchTemplate(this.template)).done(function(hasUsers, hasGroups, tmpl) {
         self.$el.html(tmpl({role: self.role.toJSON(), LANG: LANG}));
-        self.initCompletion();
+        self.initCompletion(hasGroups[0], hasUsers[0]);
       });
     }
   });


### PR DESCRIPTION
External user details service should pass group names to project admin check.
UI: user/group names completion allows new elements only in case of external groups/users.
