### PR TITLE
 [DOC-945][fix]: unescape AD user/group names before validation.

### DIFF
--- a/frontend/src/main/scala/com/griddynamics/genesis/rest/ProjectsController.scala
+++ b/frontend/src/main/scala/com/griddynamics/genesis/rest/ProjectsController.scala
@@ -110,8 +110,8 @@ class ProjectsController(projectService: ProjectService, authorityService: Proje
     assertProjectExists(projectId)
 
     val paramsMap = GenesisRestController.extractParamsMap(request)
-    val users = GenesisRestController.extractListValue("users", paramsMap)
-    val groups = GenesisRestController.extractListValue("groups", paramsMap)
+    val users = GenesisRestController.extractListValue("users", paramsMap).map(unescapeAndReplace)
+    val groups = GenesisRestController.extractListValue("groups", paramsMap).map(unescapeAndReplace)
 
     import Validation._
     val invalidUsers = users.filterNot(_.matches(validADName))
@@ -125,8 +125,8 @@ class ProjectsController(projectService: ProjectService, authorityService: Proje
 
     authorityService.updateProjectAuthority(projectId,
       GenesisRole.withName(roleName),
-      users.map(unescapeAndReplace).distinct,
-      groups.map(unescapeAndReplace).distinct)
+      users.distinct,
+      groups.distinct)
   }
 
   @RequestMapping(value = Array("{projectId}/roles/{roleName}"), method = Array(RequestMethod.GET))

--- a/ui/src/main/resources/assets/js/plugins/jquery/jquery.fcbkcomplete.js
+++ b/ui/src/main/resources/assets/js/plugins/jquery/jquery.fcbkcomplete.js
@@ -45,6 +45,10 @@
 * $(input).bind("paste", function(event) {
 *  setTimeout(function() { ... }, 100);
 * });
+*
+*
+* bindEvents() was fixed to always call xssPrevent with flag=1 to escape input values.
+*
 */
 
 (function( $, undefined ) {
@@ -378,7 +382,7 @@
 
           if ((event.keyCode == _key.enter || event.keyCode == _key.tab || event.keyCode == _key.comma) && !checkFocusOn()) {
             if (options.newel) {
-              var value = xssPrevent($(this).val());
+              var value = xssPrevent($(this).val(), 1);
               addItem(value, value, 0, 0, 1);
               return _preventDefault(event);
             }


### PR DESCRIPTION
Always escape input in fcbkcomplete.
