### PR TITLE
[DOC-XXX] [feature] - Hashed support send of complex names

### DIFF
--- a/test-automation/ruby-api/genesis_client/lib/genesis_client.rb
+++ b/test-automation/ruby-api/genesis_client/lib/genesis_client.rb
@@ -150,6 +150,21 @@ module Genesis
       end
     end
 
+    def method_missing(name, *arguments)
+      method_name = name.to_s
+      elements = method_name.split('.')
+      if elements.size < 2
+        raise NoMethodError.new("Only names with dots are expected in Hashed.method_missing, but got #{name}", name)
+      end
+      obj = self.send(elements.first)
+      if obj.class == self.class
+        obj.send(elements.drop(1).join("."))
+      else
+        obj
+      end
+    end
+
+    private
     def create_methods_from_elements(elements, v)
       if (elements.size == 1)
         create_methods(elements.first, v)
@@ -164,7 +179,12 @@ module Genesis
       else
         self.instance_variable_set("@#{k}", v)
       end
-      self.class.send :define_method, k, proc { self.instance_variable_get("@#{k}") }
+      # Here we create singleton methods because otherwise we'll create methods
+      # for all instances of a Hashed class. For example, having key as 'some.simple.val'
+      # we'll create methods :some, :simple and :val for every instance of Hashed class,
+      # though only top-level class should have method :some, and so on
+      singleton = class << self; self end
+      singleton.send :define_method, k, proc { self.instance_variable_get("@#{k}") }
     end
   end
 end

--- a/test-automation/ruby-api/genesis_client/lib/genesis_client/version.rb
+++ b/test-automation/ruby-api/genesis_client/lib/genesis_client/version.rb
@@ -1,3 +1,3 @@
 module Genesis
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/test-automation/ruby-api/genesis_client/spec/hashed_spec.rb
+++ b/test-automation/ruby-api/genesis_client/spec/hashed_spec.rb
@@ -36,6 +36,8 @@ class HashedSpec < Test::Unit::TestCase
        hashed.errors.respond_to?("compound").should eq(true)
        hashed.errors.compound.respond_to?("simple").should eq(true)
        hashed.errors.compound.simple.respond_to?("error").should eq(true)
+       hashed.instance_eval("errors.compound.simple.error").should eq("Simple error")
+       hashed.send("errors.compound.simple.error").should eq("Simple error")
      end
   end
 end


### PR DESCRIPTION
You can now do

hashed.send("some.prop.with.dots")

tested with JRuby 1.7.0 and MRI 1.9.3
