### PR TITLE
[DOC-XXX][feature] -  AST tranformation for assignement of $context  variable.

### DIFF
--- a/backend/src/main/java/com/griddynamics/genesis/template/dsl/groovy/transformations/Context.java
+++ b/backend/src/main/java/com/griddynamics/genesis/template/dsl/groovy/transformations/Context.java
@@ -1,0 +1,14 @@
+package com.griddynamics.genesis.template.dsl.groovy.transformations;
+
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@GroovyASTTransformationClass({"com.griddynamics.genesis.template.dsl.groovy.transformations.ContextASTTransformation"})
+public @interface Context {
+}

--- a/backend/src/main/scala/com/griddynamics/genesis/service/impl/GroovyTemplateService.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/service/impl/GroovyTemplateService.scala
@@ -44,6 +44,9 @@ import java.util.concurrent.TimeUnit
 import org.codehaus.groovy.runtime.{InvokerHelper, MethodClosure}
 import org.springframework.core.convert.ConversionService
 import com.griddynamics.genesis.annotation.RemoteGateway
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer
+import transformations.{Context, ContextASTTransformation}
 
 @RemoteGateway("groovy template service")
 class GroovyTemplateService(val templateRepoService : TemplateRepoService,
@@ -142,7 +145,9 @@ class GroovyTemplateService(val templateRepoService : TemplateRepoService,
     binding.setVariable("include", new MethodClosure(templateDecl, "include"))
 
     try {
-      val groovyShell = new GroovyShell(binding)
+      val compilerConfiguration = new CompilerConfiguration()
+      compilerConfiguration.addCompilationCustomizers(new ASTTransformationCustomizer(classOf[Context]))
+      val groovyShell = new GroovyShell(binding, compilerConfiguration)
       groovyShell.evaluate(body)
       projectId.foreach (evaluateIncludes(_, templateDecl.includes, groovyShell))
     } catch {

--- a/backend/src/main/scala/com/griddynamics/genesis/service/impl/GroovyTemplateService.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/service/impl/GroovyTemplateService.scala
@@ -253,8 +253,9 @@ class StepBuilderProxy(stepBuilder: StepBuilder) extends GroovyObjectSupport wit
             case (_, value: Closure[_]) =>
                 contextDependentProperties(property) = new ContextAccess {
                     def apply(v1: collection.Map[String, Any]) = {
-                        import scala.collection.JavaConversions._
-                        value.setDelegate(new Expando(v1))
+                      import scala.collection.JavaConversions._
+                      val v2: Map[String, Expando] = Map(Reserved.contextRef -> new Expando(v1))
+                        value.setDelegate(new Expando(v2))
                         value.call()
                     }
                 }

--- a/backend/src/main/scala/com/griddynamics/genesis/template/dsl/groovy/Reserved.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/template/dsl/groovy/Reserved.scala
@@ -27,4 +27,5 @@ object Reserved {
   val configRef =  "$envConfig"
   val projectRef = "$project"
   val databagsRef = "$databags"
+  val contextRef = "$context"
 }

--- a/backend/src/main/scala/com/griddynamics/genesis/template/dsl/groovy/transformations/ContextASTTransformation.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/template/dsl/groovy/transformations/ContextASTTransformation.scala
@@ -1,0 +1,75 @@
+package com.griddynamics.genesis.template.dsl.groovy.transformations
+
+import org.codehaus.groovy.transform.{GroovyASTTransformation, ASTTransformation}
+import org.codehaus.groovy.ast._
+import org.codehaus.groovy.control.{CompilePhase, SourceUnit}
+import com.griddynamics.genesis.util.Logging
+import expr._
+import stmt.ExpressionStatement
+
+@GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
+class ContextASTTransformation extends ASTTransformation with Logging {
+  def visit(nodes: Array[ASTNode], source: SourceUnit) {
+    val methods = source.getAST.getStatementBlock.getStatements
+    val it = methods.iterator().next()
+    it.visit(new VariableToClosureReplace("$context", source.getAST))
+  }
+}
+
+class VariableToClosureReplace(val name: String, val node: ModuleNode) extends CodeVisitorSupport with Logging {
+
+  override def visitBinaryExpression(expression: BinaryExpression) {
+    val rightExpression = expression.getRightExpression
+    if (rightExpression.isInstanceOf[PropertyExpression]) {
+      val propertyExpression = rightExpression.asInstanceOf[PropertyExpression]
+      if (isAppropriateExpression(propertyExpression)){
+        log.debug(s"Found appropriate assignment to ${name} variable in expression ${expression.getText}")
+        expression.setRightExpression(buildClosure(propertyExpression))
+      } else {
+        log.debug(s"Not transforming ${propertyExpression.getText}")
+      }
+    }
+  }
+
+
+  private def buildClosure(top: PropertyExpression) : ClosureExpression = {
+    val block = new ExpressionStatement(stripLeader(top))
+    val expression: ClosureExpression = new ClosureExpression(null, block)
+    expression.setVariableScope(new VariableScope())
+    expression
+  }
+
+
+  private def stripLeader(top: PropertyExpression): Expression = {
+    val (_, expressions) = getLatestPropertyExpression(top)
+    expressions match {
+      case x :: xs => {
+        val newVariable = new VariableExpression(x.asInstanceOf[ConstantExpression].getValue.toString)
+        val newTop = xs.fold(newVariable)((acc, e) => new PropertyExpression(acc, e))
+        log.debug(s"Shortened expression ${top.getText} to form ${newTop.getText}")
+        newTop
+      }
+      case _ => {
+        log.debug("Expression list was empty. No transformation applied")
+        top
+      }
+    }
+  }
+
+  private def isAppropriateExpression(top: PropertyExpression): Boolean = {
+    val (left, list) = getLatestPropertyExpression(top)
+    left.getObjectExpression.isInstanceOf[VariableExpression] &&
+      left.getObjectExpression.asInstanceOf[VariableExpression].getName == name &&
+      ! list.isEmpty
+  }
+
+  def getLatestPropertyExpression(top: PropertyExpression): (PropertyExpression, List[Expression]) = {
+    var originalExpression = top
+    var expressions: List[Expression] = List()
+    while (originalExpression.getObjectExpression.isInstanceOf[PropertyExpression]) {
+      expressions = originalExpression.getProperty :: expressions
+      originalExpression = originalExpression.getObjectExpression.asInstanceOf[PropertyExpression]
+    }
+    (originalExpression, originalExpression.getProperty :: expressions)
+  }
+}

--- a/backend/src/test/resources/groovy/ContextExample.genesis
+++ b/backend/src/test/resources/groovy/ContextExample.genesis
@@ -16,7 +16,7 @@ template {
             teststep {
                 phase = "phase2"
                 precedingPhases = ["phase1"]
-                text =   { contextVar.text }
+                text = $context.contextVar.text
             }
         }
     }


### PR DESCRIPTION
Constructions like: 

step {
    var = $context.variable
}

are transfoming to 

step {
    var = { variable }
}

Rationale: better readability
