### PR TITLE
[RJA-2226][[RJA-2227][feature] - Attachment objects for step results

### DIFF
--- a/api/src/main/scala/com/griddynamics/genesis/api/Model.scala
+++ b/api/src/main/scala/com/griddynamics/genesis/api/Model.scala
@@ -341,6 +341,8 @@ case class Link(href: String, rel: String, `type`: Option[String], methods: Arra
   def remove(method: String) = new Link(href, rel, `type`, methods.filter(_ != method))
 }
 
+case class Attachment(id: Int, description: String, attachmentType: String, stepId: Option[Int], actionUUID: Option[String])
+
 object Links {
   def merge(links: Array[Link]) = {
     val groupedByHref = links.groupBy(_.href)

--- a/backend/src/main/scala/com/griddynamics/genesis/bean/RequestDispatcher.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/bean/RequestDispatcher.scala
@@ -35,10 +35,8 @@ import com.griddynamics.genesis.model.WorkflowStatus._
 import com.griddynamics.genesis.util.Logging
 import java.sql.Timestamp
 import com.griddynamics.genesis.configuration.WorkflowConfig
-import scala.Some
 import com.griddynamics.genesis.configuration.WorkflowConfig
 import com.griddynamics.genesis.plugin.Cancel
-import scala.Tuple2
 import com.griddynamics.genesis.service.Builders
 
 trait RequestDispatcher {

--- a/backend/src/main/scala/com/griddynamics/genesis/configuration/StoreServiceContext.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/configuration/StoreServiceContext.scala
@@ -75,7 +75,9 @@ class JdbcStoreServiceContext extends StoreServiceContext {
     @Bean def serversLoanService: service.ServersLoanService = new ServersLoanServiceImpl(storeService, credentialsRepository)
     @Bean def databagRepository: repository.DatabagRepository = new repository.impl.DatabagRepository
     @Bean def databagService: service.DataBagService = new impl.DataBagServiceImpl(databagRepository, databagTemplateRepository, validators.toMap)
-
+    @Bean def attachmentContentRepository: repository.AttachmentContentRepository = new repository.impl.AttachmentContentRepositoryDBImpl
+    @Bean def attachmentRepository: repository.AttachmentRepository = new repository.impl.AttachmentRepositoryImpl
+    @Bean def attachmentService: service.AttachmentService = new service.impl.AttachmentServiceImpl(attachmentRepository, attachmentContentRepository)
 }
 
 class GenesisSchemaCreator(override val dataSource : DataSource, override val transactionManager : PlatformTransactionManager,

--- a/backend/src/main/scala/com/griddynamics/genesis/configuration/WorkflowContext.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/configuration/WorkflowContext.scala
@@ -65,7 +65,8 @@ class DefaultWorkflowContext extends WorkflowContext {
         templateService = templateServiceContext.templateService,
         executorService = executorService,
         stepCoordinatorFactory = stepCoordinatorFactory, actorSystem = actorSystem,
-        remoteAgentService = remoteAgentService)
+        remoteAgentService = remoteAgentService,
+        attachmentService = storeServiceContext.attachmentService)
     }
 
     // this executor service is used to 'asynchronously' execute SyncActionExecutors,

--- a/backend/src/main/scala/com/griddynamics/genesis/core/GenesisFlowCoordinator.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/core/GenesisFlowCoordinator.scala
@@ -25,7 +25,7 @@ package com.griddynamics.genesis.core
 import scala.collection.mutable
 import com.griddynamics.genesis.plugin._
 import com.griddynamics.genesis.workflow._
-import com.griddynamics.genesis.service.StoreService
+import com.griddynamics.genesis.service.{AttachmentService, StoreService}
 import com.griddynamics.genesis.model._
 import com.griddynamics.genesis.model.EnvStatus._
 import com.griddynamics.genesis.common.Mistake
@@ -46,15 +46,17 @@ abstract class GenesisFlowCoordinator(envId: Int,
                                       projectId: Int,
                                       flowSteps: Seq[StepBuilder],
                                       storeService: StoreService,
+                                      attachmentService: AttachmentService,
                                       stepCoordinatorFactory: StepCoordinatorFactory,
                                       rescueSteps: Seq[StepBuilder] = Seq())
-    extends GenesisFlowCoordinatorBase(envId, projectId, flowSteps, storeService, stepCoordinatorFactory, rescueSteps)
+    extends GenesisFlowCoordinatorBase(envId, projectId, flowSteps, storeService, attachmentService, stepCoordinatorFactory, rescueSteps)
     with StepIgnore with StepRestart with StepExecutionContextHolder
 
 abstract class GenesisFlowCoordinatorBase(val envId: Int,
                                           val projectId: Int,
                                           val flowSteps: Seq[StepBuilder],
                                           val storeService: StoreService,
+                                          val attachmentService: AttachmentService,
                                           val stepCoordinatorFactory: StepCoordinatorFactory,
                                           val rescueSteps: Seq[StepBuilder] = Seq())
     extends FlowCoordinator with Logging {
@@ -151,7 +153,7 @@ abstract class GenesisFlowCoordinatorBase(val envId: Int,
         safe {
             val context = createStepExecutionContext(s)
             val stepCoordinator = stepCoordinatorFactory.apply(s.actualStep, context)
-            new GenesisStepCoordinator(s, workflow, stepCoordinator, storeService)
+            new GenesisStepCoordinator(s, workflow, stepCoordinator, storeService, attachmentService)
         } {
             error => storeService.updateStepDetailsAndStatus(s.id, Some(error.getMessage), WorkflowStepStatus.Canceled)
         }

--- a/backend/src/main/scala/com/griddynamics/genesis/model/GenesisSchema.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/model/GenesisSchema.scala
@@ -66,6 +66,8 @@ trait GenesisSchema extends Schema {
     val failedJobDetails = table[FailedJobDetails]("failed_job_details")
 
     val genesisVersion = table[GenesisVersion]("genesis_version")
+    val attachments = table[Attachment]("attachments")
+    val attachmentContent = table[DBAttachmentContent]("attachment_content")
 }
 
 trait GenesisSchemaPrimitive extends GenesisSchema {
@@ -104,6 +106,9 @@ trait GenesisSchemaPrimitive extends GenesisSchema {
 
     val configToAttrs = oneToManyRelation(configuration, configAttrs).via((config, attr) => config.id === attr.entityId)
     configToAttrs.foreignKeyDeclaration.constrainReference(onDelete cascade)
+
+    val contentToAttachment = oneToManyRelation(attachments, attachmentContent).via((master, slave) => master.id === slave.attachmentId)
+    contentToAttachment.foreignKeyDeclaration.constrainReference(onDelete cascade)
 
     on(vmAttrs)(attr => declare(
         attr.value is (dbType("text"))
@@ -165,6 +170,11 @@ trait GenesisSchemaPrimitive extends GenesisSchema {
         tracking.actionUUID is dbType("varchar(36)"),
         columns(tracking.workflowStepId) are (indexed("step_idx")),
         columns(tracking.actionUUID) are (indexed("action_uuid_idx"))
+    ))
+
+    on(attachments)(attachment => declare(
+       attachment.actionUUID is dbType("varchar(36)"),
+       columns(attachment.actionUUID) are (indexed("attachment_action_idx"))
     ))
 
     on(serverArrays)(array => declare (

--- a/backend/src/main/scala/com/griddynamics/genesis/repository/impl/AttachmentContentRepositoryDBImpl.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/repository/impl/AttachmentContentRepositoryDBImpl.scala
@@ -1,0 +1,23 @@
+package com.griddynamics.genesis.repository.impl
+
+import com.griddynamics.genesis.repository.AttachmentContentRepository
+import com.griddynamics.genesis.model.{AttachmentContent, DBAttachmentContent, GenesisSchema, Attachment}
+import java.io.InputStream
+import com.griddynamics.genesis.api
+import com.griddynamics.genesis.util.Closeables
+import org.squeryl.PrimitiveTypeMode._
+
+
+class AttachmentContentRepositoryDBImpl extends AttachmentContentRepository {
+  def saveAttachmentContent(attachment: Attachment, content: InputStream) {
+      Closeables.using(content) { is =>
+        val bytes = Stream.continually(is.read()).takeWhile(-1 !=).map(_.toByte).toArray
+        is.close()
+        GenesisSchema.attachmentContent.insert(new DBAttachmentContent(bytes, attachment.id))
+      }
+  }
+
+  def getContent(attachment: api.Attachment): Option[AttachmentContent[_]] = {
+      from(GenesisSchema.attachmentContent)(item => (where(item.attachmentId === attachment.id) select item)).headOption
+  }
+}

--- a/backend/src/main/scala/com/griddynamics/genesis/repository/impl/AttachmentContentRepositoryDBImpl.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/repository/impl/AttachmentContentRepositoryDBImpl.scala
@@ -12,7 +12,6 @@ class AttachmentContentRepositoryDBImpl extends AttachmentContentRepository {
   def saveAttachmentContent(attachment: Attachment, content: InputStream) {
       Closeables.using(content) { is =>
         val bytes = Stream.continually(is.read()).takeWhile(-1 !=).map(_.toByte).toArray
-        is.close()
         GenesisSchema.attachmentContent.insert(new DBAttachmentContent(bytes, attachment.id))
       }
   }

--- a/backend/src/main/scala/com/griddynamics/genesis/repository/impl/AttachmentRepositoryImpl.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/repository/impl/AttachmentRepositoryImpl.scala
@@ -1,0 +1,27 @@
+package com.griddynamics.genesis.repository.impl
+
+import com.griddynamics.genesis.repository.AttachmentRepository
+import com.griddynamics.genesis.model.{GenesisSchema, Attachment}
+import com.griddynamics.genesis.api
+import com.griddynamics.genesis.annotation.RemoteGateway
+import org.squeryl.PrimitiveTypeMode._
+import org.springframework.transaction.annotation.Transactional
+
+@RemoteGateway("Genesis database access: GenesisVersionRepository")
+class AttachmentRepositoryImpl extends AttachmentRepository{
+
+  @Transactional(readOnly = true)
+  def findByActionUUID(actionUUID: String) = {
+    from(GenesisSchema.attachments)(item => (where(item.actionUUID === Some(actionUUID))) select(item)).toList.map(convert(_))
+  }
+
+  @Transactional(readOnly = false)
+  def insert(attachment: Attachment) : Attachment = {
+     GenesisSchema.attachments.insert(attachment)
+  }
+
+  @Transactional(readOnly = true)
+  def get(key: Int) = from(GenesisSchema.attachments)(item => (where(item.id === key)) select(item)).headOption.map(convert(_))
+
+  implicit def convert(model: Attachment) : api.Attachment = api.Attachment(model.id, model.description, model.attachmentType, model.stepId, model.actionUUID)
+}

--- a/backend/src/main/scala/com/griddynamics/genesis/service/impl/AttachmentServiceImpl.scala
+++ b/backend/src/main/scala/com/griddynamics/genesis/service/impl/AttachmentServiceImpl.scala
@@ -1,0 +1,23 @@
+package com.griddynamics.genesis.service.impl
+
+import com.griddynamics.genesis.service.AttachmentService
+import com.griddynamics.genesis.api.Attachment
+import com.griddynamics.genesis.repository.{AttachmentContentRepository, AttachmentRepository}
+import com.griddynamics.genesis.model
+import org.springframework.transaction.annotation.Transactional
+import java.io.InputStream
+
+class AttachmentServiceImpl(repository: AttachmentRepository, contentRepository: AttachmentContentRepository) extends AttachmentService {
+  @Transactional(readOnly = true)
+  def findForAction(actionUUID: String): Seq[Attachment] = repository.findByActionUUID(actionUUID)
+  @Transactional(readOnly = true)
+  def get(key: Int): Option[Attachment] = repository.get(key)
+  @Transactional(readOnly = false)
+  def insert(attachment: model.Attachment, content: InputStream): model.Attachment = {
+    val saved = repository.insert(attachment)
+    contentRepository.saveAttachmentContent(saved, content)
+    saved
+  }
+  @Transactional(readOnly = true)
+  def getContent(attachment: Attachment): Array[Byte] = contentRepository.getContent(attachment).map(_.content).getOrElse(Array())
+}

--- a/backend/src/test/scala/com/griddynamics/genesis/service/impl/ContextEnvTest.scala
+++ b/backend/src/test/scala/com/griddynamics/genesis/service/impl/ContextEnvTest.scala
@@ -26,7 +26,7 @@ import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mock.MockitoSugar
 import com.griddynamics.genesis.util.IoUtil
 import org.springframework.core.convert.support.DefaultConversionService
-import com.griddynamics.genesis.service.Builders
+import com.griddynamics.genesis.service.{AttachmentService, Builders}
 import com.griddynamics.genesis.template.ListVarDSFactory
 import org.junit.Test
 import com.griddynamics.genesis.core.{RegularWorkflow, GenesisFlowCoordinator}
@@ -56,6 +56,8 @@ class ContextEnvTest extends AssertionsForJUnit with MockitoSugar with DSLTestUn
     storeService
   }
 
+  val attachmentService = mock[AttachmentService]
+
   when(configService.getDefault(Matchers.any())).thenReturn(Some(new api.Configuration(Some(0), "", 0, None, Map())))
   when(configService.get(Matchers.any(), Matchers.any())).thenReturn(Some(new api.Configuration(Some(0), "", 0, None, Map())))
 
@@ -73,7 +75,7 @@ class ContextEnvTest extends AssertionsForJUnit with MockitoSugar with DSLTestUn
   private lazy val template = templateService.findTemplate(0, "ContextWithEnv", "0.1", 1).get
 
   private def flowCoordinator(stepBuilders: Builders) = new GenesisFlowCoordinator(0, 0, stepBuilders.regular,
-    storeService, stepCoordinatorFactory, stepBuilders.onError) with RegularWorkflow
+    storeService, attachmentService, stepCoordinatorFactory, stepBuilders.onError) with RegularWorkflow
 
   @Test def contextEnvAccess() {
     flowCoordinator(template.createWorkflow.embody(Map())).onFlowStart() match {

--- a/backend/src/test/scala/com/griddynamics/genesis/service/impl/EnvConfigTest.scala
+++ b/backend/src/test/scala/com/griddynamics/genesis/service/impl/EnvConfigTest.scala
@@ -26,7 +26,7 @@ import org.scalatest.junit.AssertionsForJUnit
 import org.scalatest.mock.MockitoSugar
 import com.griddynamics.genesis.util.IoUtil
 import org.springframework.core.convert.support.DefaultConversionService
-import com.griddynamics.genesis.service.Builders
+import com.griddynamics.genesis.service.{AttachmentService, Builders}
 import com.griddynamics.genesis.template.ListVarDSFactory
 import org.junit.Test
 import com.griddynamics.genesis.core.{RegularWorkflow, GenesisFlowCoordinator}
@@ -77,7 +77,7 @@ class EnvConfigTest extends AssertionsForJUnit with MockitoSugar with DSLTestUni
   private lazy val template = templateService.findTemplate(0, "EnvConfigTest", "0.1", 1).get
 
   private def flowCoordinator(stepBuilders: Builders) = new GenesisFlowCoordinator(0, 0, stepBuilders.regular,
-    storeService, stepCoordinatorFactory, stepBuilders.onError) with RegularWorkflow
+    storeService, mock[AttachmentService], stepCoordinatorFactory, stepBuilders.onError) with RegularWorkflow
 
   @Test def envConfigAccessInStep() {
     val workflow = template.createWorkflow

--- a/backend/src/test/scala/com/griddynamics/genesis/service/impl/GroovyTemplateContextTest.scala
+++ b/backend/src/test/scala/com/griddynamics/genesis/service/impl/GroovyTemplateContextTest.scala
@@ -37,6 +37,7 @@ import com.griddynamics.genesis.workflow.{Step, StepResult}
 import com.griddynamics.genesis.plugin.{GenesisStep, GenesisStepResult, StepCoordinatorFactory}
 import com.griddynamics.genesis.api
 import com.griddynamics.genesis.cache.NullCacheManager
+import com.griddynamics.genesis.service.AttachmentService
 
 class GroovyTemplateContextTest extends AssertionsForJUnit with MockitoSugar  with DSLTestUniverse {
 
@@ -65,7 +66,7 @@ class GroovyTemplateContextTest extends AssertionsForJUnit with MockitoSugar  wi
     val stepBuilders = templateService.findTemplate(0, "TestEnv", "0.1", 0).get.createWorkflow.embody(Map())
     stepBuilders.regular.foreach { _.id = IdGen.generate }
 
-    val flowCoordinator = new GenesisFlowCoordinator(0, 0, stepBuilders.regular, storeService, stepCoordinatorFactory, stepBuilders.onError) with RegularWorkflow
+    val flowCoordinator = new GenesisFlowCoordinator(0, 0, stepBuilders.regular, storeService, mock[AttachmentService], stepCoordinatorFactory, stepBuilders.onError) with RegularWorkflow
 
     flowCoordinator.onFlowStart()
 

--- a/frontend/src/main/scala/com/griddynamics/genesis/rest/EnvironmentsController.scala
+++ b/frontend/src/main/scala/com/griddynamics/genesis/rest/EnvironmentsController.scala
@@ -399,7 +399,7 @@ class EnvironmentsController extends RestApiExceptionsHandler {
        } else {
          response.setHeader("Content-type", att.attachmentType)
          response.setHeader("Content-length", bytes.length.toString)
-         response.setHeader("Content-Disposition", s"attachment;filename=\"${att.description}\"")
+         response.setHeader("Content-Disposition", "attachment;filename=\"" + att.description + "\"")
          out.write(bytes)
        }
        out.flush()

--- a/frontend/src/main/scala/com/griddynamics/genesis/rest/EnvironmentsController.scala
+++ b/frontend/src/main/scala/com/griddynamics/genesis/rest/EnvironmentsController.scala
@@ -36,7 +36,7 @@ import com.griddynamics.genesis.http.TunnelFilter
 import org.springframework.web.bind.annotation._
 import org.springframework.web.bind.annotation.RequestMethod._
 import org.springframework.beans.factory.annotation.{Autowired, Value}
-import com.griddynamics.genesis.service.{EnvironmentConfigurationService, EnvironmentAccessService}
+import com.griddynamics.genesis.service.{AttachmentService, EnvironmentConfigurationService, EnvironmentAccessService}
 import org.springframework.security.access.prepost.PostFilter
 import org.springframework.http.{HttpHeaders, MediaType}
 import java.util.{Date, TimeZone, Locale}
@@ -63,6 +63,7 @@ class EnvironmentsController extends RestApiExceptionsHandler {
   @Autowired implicit var linkSecurity: LinkSecurityBean = _
   @Autowired var envConfigService: EnvironmentConfigurationService = _
   @Autowired var schedulingService: EnvironmentJobService = _
+  @Autowired var attachmentService: AttachmentService = _
 
   @Value("${genesis.system.server.mode:frontend}")
   var mode = ""
@@ -374,6 +375,14 @@ class EnvironmentsController extends RestApiExceptionsHandler {
                      request: HttpServletRequest): Seq[ActionTracking] = {
     validateStepId(stepId, envId)
     genesisService.getStepLog(stepId)
+  }
+
+  @RequestMapping(value = Array("{envId}/steps/{stepId}/actions/{uuid}/attachments"), method = Array(RequestMethod.GET))
+  @ResponseBody
+  def getActionAttachments(@PathVariable("projectId") projectId: Int,
+  @PathVariable("envId") envId: Int, @PathVariable("stepId") stepId: Int, @PathVariable("uuid") actionUUID: String, request: HttpServletRequest): Seq[Attachment] = {
+    validateStepId(stepId, envId)
+    attachmentService.findForAction(actionUUID)
   }
 
   @RequestMapping(value = Array("{envId}"), method = Array(RequestMethod.PUT))

--- a/frontend/src/main/scala/com/griddynamics/genesis/rest/EnvironmentsController.scala
+++ b/frontend/src/main/scala/com/griddynamics/genesis/rest/EnvironmentsController.scala
@@ -396,7 +396,6 @@ class EnvironmentsController extends RestApiExceptionsHandler {
        val out = response.getOutputStream
        if (bytes.isEmpty) {
          response.setStatus(HttpServletResponse.SC_NO_CONTENT)
-         out.flush()
        } else {
          response.setHeader("Content-type", att.attachmentType)
          response.setHeader("Content-length", bytes.length.toString)

--- a/internal-api/src/main/scala/com/griddynamics/genesis/configuration/StoreServiceContext.scala
+++ b/internal-api/src/main/scala/com/griddynamics/genesis/configuration/StoreServiceContext.scala
@@ -22,7 +22,7 @@
  */
 package com.griddynamics.genesis.configuration
 
-import com.griddynamics.genesis.service.{EnvironmentConfigurationService, CredentialsStoreService, StoreService}
+import com.griddynamics.genesis.service.{AttachmentService, EnvironmentConfigurationService, CredentialsStoreService, StoreService}
 import com.griddynamics.genesis.repository.{DatabagRepository, ProjectRepository}
 import com.griddynamics.genesis.repository
 
@@ -33,5 +33,6 @@ trait StoreServiceContext {
   def credentialsStoreService: CredentialsStoreService
   def configurationRepository: repository.ConfigurationRepository
   def environmentService: EnvironmentConfigurationService
+  def attachmentService: AttachmentService
 }
 

--- a/internal-api/src/main/scala/com/griddynamics/genesis/model/Attachment.scala
+++ b/internal-api/src/main/scala/com/griddynamics/genesis/model/Attachment.scala
@@ -1,0 +1,12 @@
+package com.griddynamics.genesis.model
+
+class Attachment(val actionUUID: Option[String], val stepId: Option[Int], val attachmentType: String, val description: String)
+  extends GenesisEntity {
+}
+
+class DBAttachmentContent(val content: Array[Byte], val attachmentId: GenesisEntity.Id) extends AttachmentContent[GenesisEntity.Id] with GenesisEntity
+
+trait AttachmentContent[B] {
+  def content: Array[Byte]
+  def attachmentId: B
+}

--- a/internal-api/src/main/scala/com/griddynamics/genesis/repository/AttachmentContentRepository.scala
+++ b/internal-api/src/main/scala/com/griddynamics/genesis/repository/AttachmentContentRepository.scala
@@ -1,0 +1,10 @@
+package com.griddynamics.genesis.repository
+
+import com.griddynamics.genesis.model.{AttachmentContent, Attachment}
+import com.griddynamics.genesis.api
+import java.io.InputStream
+
+trait AttachmentContentRepository {
+   def saveAttachmentContent(attachment: Attachment, content: InputStream)
+   def getContent(attachment: api.Attachment): Option[AttachmentContent[_]]
+}

--- a/internal-api/src/main/scala/com/griddynamics/genesis/repository/AttachmentRepository.scala
+++ b/internal-api/src/main/scala/com/griddynamics/genesis/repository/AttachmentRepository.scala
@@ -1,0 +1,10 @@
+package com.griddynamics.genesis.repository
+
+import com.griddynamics.genesis.api.{Attachment => Api}
+import com.griddynamics.genesis.model.Attachment
+
+trait AttachmentRepository {
+   def findByActionUUID(actionUUID: String) : Seq[Api]
+   def insert(attachment: Attachment) : Attachment
+   def get(key: Int): Option[Api]
+}

--- a/internal-api/src/main/scala/com/griddynamics/genesis/service/AttachmentService.scala
+++ b/internal-api/src/main/scala/com/griddynamics/genesis/service/AttachmentService.scala
@@ -1,0 +1,11 @@
+package com.griddynamics.genesis.service
+
+import com.griddynamics.genesis.api
+import com.griddynamics.genesis.model
+import java.io.InputStream
+
+trait AttachmentService{
+  def findForAction(actionUUID: String): Seq[api.Attachment]
+  def get(key: Int): Option[api.Attachment]
+  def insert(attachment: model.Attachment, content: InputStream): model.Attachment
+}

--- a/internal-api/src/main/scala/com/griddynamics/genesis/service/AttachmentService.scala
+++ b/internal-api/src/main/scala/com/griddynamics/genesis/service/AttachmentService.scala
@@ -3,9 +3,11 @@ package com.griddynamics.genesis.service
 import com.griddynamics.genesis.api
 import com.griddynamics.genesis.model
 import java.io.InputStream
+import com.griddynamics.genesis.api.Attachment
 
 trait AttachmentService{
   def findForAction(actionUUID: String): Seq[api.Attachment]
   def get(key: Int): Option[api.Attachment]
   def insert(attachment: model.Attachment, content: InputStream): model.Attachment
+  def getContent(attachment: Attachment): Array[Byte]
 }

--- a/internal-api/src/main/scala/com/griddynamics/genesis/workflow/Action.scala
+++ b/internal-api/src/main/scala/com/griddynamics/genesis/workflow/Action.scala
@@ -23,7 +23,8 @@
 package com.griddynamics.genesis.workflow
 
 import java.util
-import com.griddynamics.genesis.model.ActionTrackingStatus
+import com.griddynamics.genesis.model.{Attachment, ActionTrackingStatus}
+import java.io.{FileInputStream, File, InputStream}
 
 /* Marker trait for any particular action */
 trait Action {
@@ -52,6 +53,26 @@ trait ActionFailed extends ActionResult {
 
 trait ActionInterrupted extends ActionResult {
     override def outcome = ActionTrackingStatus.Interrupted
+}
+
+trait ResultWithAttachment {
+  def attachments: Seq[Attachable]
+}
+
+trait Attachable {
+  def getInputStream: InputStream
+  def getName: String
+  def getType: String
+}
+
+class FileAttachable(file: File, `type`: String = "text/plain" ) extends Attachable {
+  def getInputStream: InputStream = new FileInputStream(file)
+  def getName = file.getName
+  def getType = `type`
+}
+
+object FileAttachable {
+  def apply(s: String) = new FileAttachable(new File(s))
 }
 
 

--- a/ui/src/main/resources/genesis/app/modules/env_details/history.js
+++ b/ui/src/main/resources/genesis/app/modules/env_details/history.js
@@ -99,6 +99,18 @@ function (genesis, Backbone, status, $) {
         json.finished = new Date(json.finishedTimestamp);
       }
       return json;
+    },
+
+    isFinished: function() {
+      return this.get('finished');
+    },
+
+    attachments: function() {
+      if (this.get('finished')) {
+        return new AttachmentCollection(this.get("projectId"), this.get("envId"), this.get("stepId"), this.get("uuid"));
+      } else {
+        return [];
+      }
     }
   });
 
@@ -114,6 +126,25 @@ function (genesis, Backbone, status, $) {
     url: function() {
       return "rest/projects/" + this.projectId + "/envs/" + this.envId + "/steps/" + this.stepId + "/actions";
     }
+  });
+
+  var AttachmentModel = Backbone.Model.extend({
+
+  });
+
+  var AttachmentCollection = Backbone.Collection.extend({
+     model: AttachmentModel,
+
+     initialize: function(options) {
+       this.projectId = options.projectId;
+       this.envId = options.envId;
+       this.stepId = options.stepId;
+       this.actionUUID = options.uuid;
+     },
+
+     url: function() {
+       return "rest/projects/" + this.projectId + "/envs/" + this.envId + "/steps/" + this.stepId + "/actions" + this.actionUUID + "/attachments";
+     }
   });
 
   var StepLogView = Backbone.View.extend({


### PR DESCRIPTION
Example usage in step executor:

``` scala
class RunLocalActionExecutor(val action: RunLocalShell, shellService: LocalShellExecutionService) extends SyncActionExecutor {
  def startSync() = {
    val result = shellService.exec(action.shell, action.command, action.outputDirectory, Option(action))
    new RunLocalResult(action, result, Seq(FileAttachable("/etc/passwd")))
  }
}



case class RunLocalResult(action: RunLocalShell, response: ExecResponse, attachments: Seq[Attachable]) extends ActionResultWithDesc with ResultWithAttachment {
    override def outcome = if (response.exitCode == action.expectedExitCode)
        Succeed
    else
        Failed
}
```
